### PR TITLE
Updating spacy model version typo

### DIFF
--- a/deployments/python3.8/arns/ap-east-1.csv
+++ b/deployments/python3.8/arns/ap-east-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:01:19,arn:aws:lambda:ap-east-1:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:01:09,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:02:54,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:46,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:19,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ap-northeast-1.csv
+++ b/deployments/python3.8/arns/ap-northeast-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:01:02,arn:aws:lambda:ap-northeast-1:7706934
 spacy,2.3.2,deprecated,2020-10-02T02:00:52,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:04:56,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:24,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:46,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-northeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ap-northeast-2.csv
+++ b/deployments/python3.8/arns/ap-northeast-2.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:02:06,arn:aws:lambda:ap-northeast-2:7706934
 spacy,2.3.2,deprecated,2020-10-02T02:04:50,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:01:08,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:18,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:33,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ap-south-1.csv
+++ b/deployments/python3.8/arns/ap-south-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:03:17,arn:aws:lambda:ap-south-1:77069342192
 spacy,2.3.2,deprecated,2020-10-02T02:04:21,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:02:37,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:03,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:40,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ap-southeast-1.csv
+++ b/deployments/python3.8/arns/ap-southeast-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:01:50,arn:aws:lambda:ap-southeast-1:7706934
 spacy,2.3.2,deprecated,2020-10-02T02:01:28,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:04:13,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:39,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:27,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-southeast-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ap-southeast-2.csv
+++ b/deployments/python3.8/arns/ap-southeast-2.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:04:23,arn:aws:lambda:ap-southeast-2:7706934
 spacy,2.3.2,deprecated,2020-10-02T02:03:06,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:03:54,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:57,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:49,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ap-southeast-2:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/ca-central-1.csv
+++ b/deployments/python3.8/arns/ca-central-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:02:28,arn:aws:lambda:ca-central-1:770693421
 spacy,2.3.2,deprecated,2020-10-02T02:02:35,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:01:43,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:51,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:36,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:ca-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/eu-central-1.csv
+++ b/deployments/python3.8/arns/eu-central-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:04:05,arn:aws:lambda:eu-central-1:770693421
 spacy,2.3.2,deprecated,2020-10-02T02:05:16,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:03:39,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:33,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:58,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:eu-central-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/eu-north-1.csv
+++ b/deployments/python3.8/arns/eu-north-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:02:42,arn:aws:lambda:eu-north-1:77069342192
 spacy,2.3.2,deprecated,2020-10-02T02:04:03,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:00:52,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:51,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:29,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:eu-north-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/eu-west-1.csv
+++ b/deployments/python3.8/arns/eu-west-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:02:18,arn:aws:lambda:eu-west-1:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:04:36,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:05:08,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:36,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:13,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:eu-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/eu-west-2.csv
+++ b/deployments/python3.8/arns/eu-west-2.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:03:30,arn:aws:lambda:eu-west-2:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:02:10,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:04:39,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:45,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:33,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:eu-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/eu-west-3.csv
+++ b/deployments/python3.8/arns/eu-west-3.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:01:31,arn:aws:lambda:eu-west-3:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:02:23,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:03:07,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:47,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:54,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:eu-west-3:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/me-south-1.csv
+++ b/deployments/python3.8/arns/me-south-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:02:59,arn:aws:lambda:me-south-1:77069342192
 spacy,2.3.2,deprecated,2020-10-02T02:03:23,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:03:25,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:42,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:08,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:me-south-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/sa-east-1.csv
+++ b/deployments/python3.8/arns/sa-east-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:04:51,arn:aws:lambda:sa-east-1:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:03:49,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:01:58,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:07,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:43,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:sa-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/us-east-1.csv
+++ b/deployments/python3.8/arns/us-east-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:00:46,arn:aws:lambda:us-east-1:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:03:35,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:04:25,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:26,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:50,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:us-east-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/us-east-2.csv
+++ b/deployments/python3.8/arns/us-east-2.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:03:51,arn:aws:lambda:us-east-2:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:01:54,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:01:18,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:28,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:23,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:us-east-2:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/us-west-1.csv
+++ b/deployments/python3.8/arns/us-west-1.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:04:36,arn:aws:lambda:us-west-1:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:05:03,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:01:31,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:00:31,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:00:38,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:us-west-1:770693421928:layer:Klayers-python38-SQLAlchemy:8

--- a/deployments/python3.8/arns/us-west-2.csv
+++ b/deployments/python3.8/arns/us-west-2.csv
@@ -247,7 +247,7 @@ spacy,2.3.2,deprecated,2020-09-25T02:03:41,arn:aws:lambda:us-west-2:770693421928
 spacy,2.3.2,deprecated,2020-10-02T02:01:42,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-spacy:22
 spacy,2.3.2,deprecated,2020-10-09T02:02:19,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-spacy:23
 spacy,2.3.2,latest,,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-spacy:24
-spacy_model_en_small,2.25,latest,,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
+spacy_model_en_small,2.2.5,latest,,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-spacy_model_en_small:1
 SQLAlchemy,1.3.17,deprecated,2020-08-28T02:01:12,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:6
 SQLAlchemy,1.3.18,deprecated,2020-10-23T02:01:03,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:7
 SQLAlchemy,1.3.19,latest,,arn:aws:lambda:us-west-2:770693421928:layer:Klayers-python38-SQLAlchemy:8


### PR DESCRIPTION
Just a small typo on the version number of the spacy models, should read `2.2.5` instead of `2.25`. Thanks for the tip previously, hope this is helpful.