### PR TITLE
Add gremlinpython package.

### DIFF
--- a/pipeline/config/packages_p38.csv
+++ b/pipeline/config/packages_p38.csv
@@ -97,3 +97,4 @@ ccxt,MIT License (MIT),igor.kroitor@gmail.com
 pybit,MIT License (MIT License),verata@pm.me
 ccxtpro,MIT License (MIT),igor.kroitor@gmail.com
 pdf2image,MIT License (MIT),Belval <github@belval.org>
+gremlinpython,Apache-2.0,stephen mallette <stepmall@amazon.com>

--- a/pipeline/config/packages_p39.csv
+++ b/pipeline/config/packages_p39.csv
@@ -31,3 +31,4 @@ mysql-connector-python,GNU GPLv2,Oracle
 Metaphone,BSD,Andrew Collins <AtomBoy@SWCP.com>
 usaddress,MIT,Datamade <info@datamade.us>
 pyephem,MIT,Brandon Craig Rhodes <brandon@rhodesmill.org>
+gremlinpython,Apache-2.0,stephen mallette <stepmall@amazon.com>


### PR DESCRIPTION
This package is used for communication with Apache Tinkerpop.
It is also used for communicating with Neptune and therefore likely to be used in Lambda.