### PR TITLE
Add oracledb

### DIFF
--- a/pipeline/config/packages_p39.csv
+++ b/pipeline/config/packages_p39.csv
@@ -32,3 +32,4 @@ Metaphone,BSD,Andrew Collins <AtomBoy@SWCP.com>
 usaddress,MIT,Datamade <info@datamade.us>
 pyephem,MIT,Brandon Craig Rhodes <brandon@rhodesmill.org>
 gremlinpython,Apache-2.0,stephen mallette <stepmall@amazon.com>
+oracledb,Apache-2.0,anthony-tuininga (Oracle)


### PR DESCRIPTION
Add oracledb package (https://github.com/oracle/python-oracledb). Useful when having an Oracle RDS.