### PR TITLE
Adding GeoAlchemy2

### DIFF
--- a/pipeline/config/packages_p39.csv
+++ b/pipeline/config/packages_p39.csv
@@ -46,3 +46,4 @@ python-docx,MIT,<stcanny@gmail.com>
 xmltodict,MIT,Martin Blech <martinblech@gmail.com>
 dask,BSD, Matthew Rocklin
 google-api-python-client,Apache-2.0,Google LLC <googleapis-packages@google.com>
+GeoAlchemy2,MIT,GeoAlchemy


### PR DESCRIPTION
Hi @keithrozario

Could you add [GeoAlchemy2](https://geoalchemy-2.readthedocs.io/)? ([Repo](https://github.com/geoalchemy/geoalchemy2) & [Pypi](https://pypi.org/project/GeoAlchemy2/))

Thanks for this awesome repo!
