### PR TITLE
Fix malformed python package CSV

### DIFF
--- a/pipeline/config/packages_p39.csv
+++ b/pipeline/config/packages_p39.csv
@@ -39,7 +39,7 @@ PyJWT,MIT,Jose Padilla <https://github.com/jpadilla>
 kafka-python,Apache-2.0,Dana Powers
 lxml,BSD,<lxml-dev@lxml.de>
 sklearn,BSD,<scikit-learn@python.org>
-transformers,Apache-2.0,Thomas Wolf,<api-enterprise@huggingface.co>
+transformers,Apache-2.0,Thomas Wolf <api-enterprise@huggingface.co>
 selenium,Apache-2.0,The Selenium Project
 jieba,MIT,Sun Junyi,<ccnusjy@gmail.com>
 python-docx,MIT,<stcanny@gmail.com>


### PR DESCRIPTION
In #240 the python package `transformers` was added for Python 3.9 but the CSV syntax was incorrect. This fixes the mistake.