### PR TITLE
Added Pillow to packages_p310.csv

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -14,3 +14,4 @@ pyqldb,Apache-2.0,AWS
 redshift-connector,Apache License Version 2.0,Amazon Web Services <redshift-drivers@amazon.com>
 requests,Apache-2.0,Kenneth Reitz <me@kennethreitz.org>
 mysql-connector-python,GNU GPLv2,Oracle
+Pillow,https://github.com/python-pillow/Pillow/blob/main/LICENSE,Jeffrey A. Clark


### PR DESCRIPTION
It would be nice if we can add Pillow to Python 3.10. It was part of Python 3.8 which will be deprecate soon.