### PR TITLE
New layers for data processing, apis, and AWS

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -22,3 +22,8 @@ mysql-connector-python,GNU GPLv2,Oracle
 Pillow,https://github.com/python-pillow/Pillow/blob/main/LICENSE,Jeffrey A. Clark
 aliyun-python-sdk-actiontrail,Apache-2.0,Aliyun <aliyun-developers-efficiency@list.alibaba-inc.com>
 tabulate,MIT,s.astanin@gmail.com
+paramiko,GNU GPLv2,Jeff Forcier <jeff@bitprophet.org>
+pydantic,MIT,Samuel Colvin <s@muelcolvin.com>
+polars,MIT,Ritchie Vink <ritchie46@gmail.com>
+s3fs,BSD,Matthew Rocklin
+zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>

--- a/pipeline/config/packages_p311.csv
+++ b/pipeline/config/packages_p311.csv
@@ -22,3 +22,8 @@ elasticsearch,Apache-2.0,Honza Kral <honza.kral@gmail.com>; Nick Lang <nick@nick
 Pillow,https://github.com/python-pillow/Pillow/blob/master/LICENSE,Alex Clark <aclark@aclark.net>
 pymysql,MIT,songofacandy@gmail.com
 selenium,Apache Software License (Apache 2.0),The Selenium Project
+paramiko,GNU GPLv2,Jeff Forcier <jeff@bitprophet.org>
+pydantic,MIT,Samuel Colvin <s@muelcolvin.com>
+polars,MIT,Ritchie Vink <ritchie46@gmail.com>
+s3fs,BSD,Matthew Rocklin
+zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>


### PR DESCRIPTION
Added the following python packages for the two most recent Python versions (3.10 and 3.11):

paramiko
pydantic 
polars
s3fs 
zeep