### PR TITLE
Adding mangum and fastapi to CSVs

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -6,8 +6,10 @@ beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
+fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au
 jinja2,BSD,Armin Ronache <armin.ronacher@active-4.com>; Pallets <contact@palletsprojects.com>
+mangum, MIT, Jordan Eremieff
 numpy,https://www.numpy.org/license.html,numpy-discussion@python.org
 openpyxl,MIT,Charlie Clark <charlie.clark@clark-consulting.eu>
 pandas,BSD,<pydata@googlegroups.com>

--- a/pipeline/config/packages_p311.csv
+++ b/pipeline/config/packages_p311.csv
@@ -6,8 +6,10 @@ beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
+fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au
 jinja2,BSD,Armin Ronache <armin.ronacher@active-4.com>; Pallets <contact@palletsprojects.com>
+mangum, MIT, Jordan Eremieff
 matplotlib,PSF,matplotlib-users@python.org
 mysql-connector-python,GNU GPLv2,Oracle
 numpy,https://www.numpy.org/license.html,numpy-discussion@python.org

--- a/pipeline/config/packages_p38.csv
+++ b/pipeline/config/packages_p38.csv
@@ -25,6 +25,7 @@ dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 elasticsearch,Apache-2.0,Honza Kral <honza.kral@gmail.com>; Nick Lang <nick@nicklang.com>
 envelopes,MIT,tomekwojcik <tomek@bthlabs.pl>
 exchangelib,BSD, Erik Cederstrand <erik@cederstrand.dk>
+fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>
 ffmpeg-python,Apache-2.0,Karl Kroening <karlk@kralnet.us>
 flashtext,MIT,Vikash Singh <vikash.duliajan@gmail.com>
 geopy,MIT,Kostya Esmukov <kostya@esmukov.ru>
@@ -45,6 +46,7 @@ ldap3,LGPLv3, Giovanni Cannata <cannatag@gmail.com>
 langdetect,Apache-2.0,Michal Mimino Danilak <michal.danilak@gmail.com>
 loguru,MIT,Delgan <delgan.py@gmail.com>
 lxml,BSD,<lxml-dev@lxml.de>
+mangum, MIT, Jordan Eremieff
 matplotlib,PSF,matplotlib-users@python.org
 mpld3,BSD,<jakevdp@cs.washington.edu>
 nltk,Apache-2.0,Steven Bird <stevenbird1@gmail.com>

--- a/pipeline/config/packages_p39.csv
+++ b/pipeline/config/packages_p39.csv
@@ -8,8 +8,10 @@ boto3,Apache-2.0,AWS
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 DBnomics,GNU Affero General Public License v3 (AGPLv3),DBnomics Team <contact@nomics.world>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
+fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au
 jinja2,BSD,Armin Ronache <armin.ronacher@active-4.com>; Pallets <contact@palletsprojects.com>
+mangum, MIT, Jordan Eremieff
 numpy,https://www.numpy.org/license.html,numpy-discussion@python.org
 pandas,BSD,<pydata@googlegroups.com>
 pendulum,MIT,<sebastien@eustace.io>


### PR DESCRIPTION
Hey there!  Requesting a layer for FastAPI and Mangum together.  FastAPI I think is self-explanatory, but in order to make use of it within AWS Lambda, you need to wrap it with Mangum.  Requesting for multiple versions because I run into customers all the time making use of FastAPI going back to Python 3.7.x, even though its going through deprecation.

Please let me know if there is any more information I can add for you or help out in some other way!