### PR TITLE
Add scipy

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -29,4 +29,4 @@ pydantic,MIT,Samuel Colvin <s@muelcolvin.com>
 polars,MIT,Ritchie Vink <ritchie46@gmail.com>
 s3fs,BSD,Matthew Rocklin
 zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>
-scipy,BSD,scipy-dev@python.org
+scipy,BSD-3-Clause,scipy-dev@python.org

--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -29,3 +29,4 @@ pydantic,MIT,Samuel Colvin <s@muelcolvin.com>
 polars,MIT,Ritchie Vink <ritchie46@gmail.com>
 s3fs,BSD,Matthew Rocklin
 zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>
+scipy,BSD,scipy-dev@python.org


### PR DESCRIPTION
Related to #360 . I added it only for one architecture and one Python version to first test if size is an issue. If it works, adding it for the other architectures/Python versions should go smoothly.

It might make sense to wait a few days as SciPy 1.12.0 is about to be relased soon: https://github.com/scipy/scipy/releases/tag/v1.12.0rc2