### PR TITLE
llama-index packages_p310.csv

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -31,3 +31,4 @@ s3fs,BSD,Matthew Rocklin
 zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>
 scipy,BSD-3-Clause,scipy-dev@python.org
 openai,Apache Software License,support@openai.com
+llama-index,MIT,Jerry Liu <jerryjliu98@gmail.com>


### PR DESCRIPTION
LlamaIndex to build RAG apps.  Python 3.9+