### PR TITLE
Add praw package for python 3.10, 3.11 and 3.12

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -32,3 +32,4 @@ zeep,MIT, Michael van Tellingen <michaelvantellingen@gmail.com>
 scipy,BSD-3-Clause,scipy-dev@python.org
 openai,Apache Software License,support@openai.com
 llama-index,MIT,Jerry Liu <jerryjliu98@gmail.com>
+praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>

--- a/pipeline/config/packages_p311.csv
+++ b/pipeline/config/packages_p311.csv
@@ -41,3 +41,4 @@ polars, MIT, Ritchie Vink <ritchie46@gmail.com>
 msal, MIT, Microsoft
 lxml, BSD, Infrae <http://consulting.behnel.de/>
 reportlab, BSD, ReportLab Europe Ltd. <reportlab-users@lists2.reportlab.com>
+praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>

--- a/pipeline/config/packages_p312.csv
+++ b/pipeline/config/packages_p312.csv
@@ -21,3 +21,4 @@ python-pptx, MIT, python-pptx <python-pptx@googlegroups.com>
 memray, Apache 2.0, godlygeek pablogsal
 polars, MIT, Ritchie Vink <ritchie46@gmail.com>
 Pillow,https://github.com/python-pillow/Pillow/blob/master/LICENSE,Alex Clark <aclark@aclark.net>
+praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>


### PR DESCRIPTION
Hi!  This PR adds the [praw](https://github.com/praw-dev/praw) package for 3.10, 3.11 and 3.12 (it was present for earlier Python versions: https://github.com/keithrozario/Klayers/pull/181).

Let me know what you think and if anything else needs doing, thanks!