### PR TITLE
Added icalendar to P312

### DIFF
--- a/pipeline/config/packages_p312.csv
+++ b/pipeline/config/packages_p312.csv
@@ -41,3 +41,4 @@ mail-parser,Apache-2.0,mantuano.fedele@gmail.com
 pyyaml,MIT,https://pypi.org/project/PyYAML/
 gspread,MIT, Anton Burnashev <fuss.here@gmail.com>
 pymongo, Apache-2.0, The MongoDB Python Team
+icalendar,BSD,Plone Foundation <plone-developers@lists.sourceforge.net>


### PR DESCRIPTION
Adds [icalendar](https://pypi.org/project/icalendar/) to the list of Python 3.12 layers.