### PR TITLE
new arn needed for snowflake connector python

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -35,3 +35,4 @@ llama-index,MIT,Jerry Liu <jerryjliu98@gmail.com>
 praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>
 jsonschema,MIT,Julian Berman <jsonschema@GrayVines.com>
 pymssql, LGPL-2.1, https://github.com/pymssql/pymssql
+snowflake-connector-python,latest,

--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -35,4 +35,4 @@ llama-index,MIT,Jerry Liu <jerryjliu98@gmail.com>
 praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>
 jsonschema,MIT,Julian Berman <jsonschema@GrayVines.com>
 pymssql, LGPL-2.1, https://github.com/pymssql/pymssql
-snowflake-connector-python,latest,
+snowflake-connector-python,Apache 2.0,Snowflake Inc


### PR DESCRIPTION
I was working on a lambda function which needed both pyarrow and snowflake connector. But both module size is large I cant upload as layers. So I need the arn for us-east-1 for x86-64 arch of snowflake-connector-python.