### PR TITLE
ENH: add pandera

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -38,3 +38,4 @@ pymssql, LGPL-2.1, https://github.com/pymssql/pymssql
 snowflake-connector-python,Apache 2.0,Snowflake Inc
 jwcrypto,LGPLv3+,JWCrypto Project Contributors
 matplotlib,PSF,matplotlib-users@python.org
+pandera,MIT,Niels Bantilan

--- a/pipeline/config/packages_p311.csv
+++ b/pipeline/config/packages_p311.csv
@@ -44,3 +44,4 @@ reportlab, BSD, ReportLab Europe Ltd. <reportlab-users@lists2.reportlab.com>
 praw,https://github.com/praw-dev/praw/blob/master/LICENSE.txt,Bryce Boe <bbzbryce@gmail.com>
 jsonschema,MIT,Julian Berman <jsonschema@GrayVines.com>
 PyMuPDF,AGPL,Jorj X. McKie <jorj.x.mckie@outlook.de>
+pandera,MIT,Niels Bantilan

--- a/pipeline/config/packages_p312.csv
+++ b/pipeline/config/packages_p312.csv
@@ -52,3 +52,4 @@ pytz,MIT, stuart@stuartbishop.net
 amazon-textract-caller,Apache-2.0,AWS
 curl_cffi,MIT License, Lyonnet <infinitesheldon@gmail.com>
 mysqlclient, GNU General Public License v2 or later (GPLv2+), Inada Naoki
+pandera,MIT,Niels Bantilan


### PR DESCRIPTION
This adds [pandera](https://pandera.readthedocs.io/en/latest/index.html), a popular library for data validation of dataframe libraries (pandas, polars , ...). pandera is kind of an analogon to pydantic for dataframes and very useful for data pipelines. Thanks in advance.

If I understand correctly, the layers would automatically be available on the second of the month after merging according to the readme?