### PR TITLE
pyOpenSSL support for Python 3.12

### DIFF
--- a/pipeline/config/packages_p312-arm64.csv
+++ b/pipeline/config/packages_p312-arm64.csv
@@ -20,3 +20,4 @@ fake-useragent, Apache-2.0, Melroy van den Berg <melroy@melroy.org>
 stripe,MIT,Stripe <support@stripe.com>
 "psycopg[binary,pool]", LGPL-3.0, Daniele Varrazzo <daniele.varrazzo@gmail.com>
 huggingface_hub,Apache,julien@huggingface.co
+pyopenssl,Apache-2.0,https://github.com/pyca/pyopenssl

--- a/pipeline/config/packages_p312.csv
+++ b/pipeline/config/packages_p312.csv
@@ -53,3 +53,4 @@ amazon-textract-caller,Apache-2.0,AWS
 curl_cffi,MIT License, Lyonnet <infinitesheldon@gmail.com>
 mysqlclient, GNU General Public License v2 or later (GPLv2+), Inada Naoki
 pandera,MIT,Niels Bantilan
+pyopenssl,Apache-2.0,https://github.com/pyca/pyopenssl


### PR DESCRIPTION
I was using it in Python 3.8 to create JWT keypairs. But it is deprecated. Adding it again for Python 3.12