### PR TITLE
Please Add latest redis package to python3.10

### DIFF
--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -41,3 +41,4 @@ matplotlib,PSF,matplotlib-users@python.org
 pandera,MIT,Niels Bantilan
 weasyprint,BSD, Kozea <https://www.courtbouillon.org>
 pyodbc,MIT,Michael Kleehammer
+redis,MIT,Redis Inc. <oss@redis.com>

--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -42,3 +42,4 @@ pandera,MIT,Niels Bantilan
 weasyprint,BSD, Kozea <https://www.courtbouillon.org>
 pyodbc,MIT,Michael Kleehammer
 redis,MIT,Redis Inc. <oss@redis.com>
+aiohttp,Apache-2.0,aiohttp team <team@aiohttp.org>


### PR DESCRIPTION
I would like to request that you add the redis package for python3.10 to your Klayers, especially for the eu-central-1 region. 
Thanks in advance. 