### PR TITLE
Support cfnresponse in Python 3.10, 3.11, 3.12

### DIFF
--- a/pipeline/config/packages_p310-arm64.csv
+++ b/pipeline/config/packages_p310-arm64.csv
@@ -1,5 +1,6 @@
 Package_Name,License,Authors/Maintainers
 aws-xray-sdk,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 aws-requests-auth,BSD,davehmuller@gmail.com
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>

--- a/pipeline/config/packages_p310.csv
+++ b/pipeline/config/packages_p310.csv
@@ -4,6 +4,7 @@ aws-requests-auth,BSD,davehmuller@gmail.com
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>

--- a/pipeline/config/packages_p311-arm64.csv
+++ b/pipeline/config/packages_p311-arm64.csv
@@ -4,6 +4,7 @@ aws-requests-auth,BSD,davehmuller@gmail.com
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au

--- a/pipeline/config/packages_p311.csv
+++ b/pipeline/config/packages_p311.csv
@@ -5,6 +5,7 @@ aws-requests-auth,BSD,davehmuller@gmail.com
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 fastapi, MIT, Sebastián Ramírez <tiangolo@gmail.com>

--- a/pipeline/config/packages_p312-arm64.csv
+++ b/pipeline/config/packages_p312-arm64.csv
@@ -4,6 +4,7 @@ aws-requests-auth,BSD,davehmuller@gmail.com
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au

--- a/pipeline/config/packages_p312.csv
+++ b/pipeline/config/packages_p312.csv
@@ -4,6 +4,7 @@ aws-requests-auth,BSD,davehmuller@gmail.comhalley@dnspython.org
 bcrypt,Apache-2.0,cryptography-dev@python.org
 beautifulsoup4,MIT,Leonard Richardson <leonardr@segfault.org>
 boto3,Apache-2.0,AWS
+cfnresponse,Apache-2.0,Amazon Web Services
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
 dynamodb-encryption-sdk,Apache-2.0,<aws-cryptools@amazon.com>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au


### PR DESCRIPTION
Addressing #497

This PR leverages the cfnresponse lib [1][2], which uses the code provided by AWS [3].


[1] https://pypi.org/project/cfnresponse/
[2] https://github.com/gene1wood/cfnresponse
[3] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html#cfn-lambda-function-code-cfnresponsemodule-examples