### PR TITLE
Adding Pillow to v3.13

### DIFF
--- a/pipeline/config/packages_p313-arm64.csv
+++ b/pipeline/config/packages_p313-arm64.csv
@@ -2,3 +2,4 @@ Package_Name,License,Authors/Maintainers
 requests,Apache-2.0,Kenneth Reitz <me@kennethreitz.org>
 idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.com.au
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
+Pillow,https://github.com/python-pillow/Pillow/blob/master/LICENSE,Alex Clark <aclark@aclark.net>

--- a/pipeline/config/packages_p313.csv
+++ b/pipeline/config/packages_p313.csv
@@ -4,3 +4,4 @@ idna,https://github.com/kjd/idna/blob/master/LICENSE.rst,Kim Davis kim@cynosure.
 pdfplumber,MIT,Jeremy Singer-Vine
 PyMuPDF,AGPL,Jorj X. McKie <jorj.x.mckie@outlook.de>
 cryptography,Apache-2.0,The Python Cryptographic Authority and individual contributors <cryptography-dev@python.org>
+Pillow,https://github.com/python-pillow/Pillow/blob/master/LICENSE,Alex Clark <aclark@aclark.net>


### PR DESCRIPTION
Requesting to add Pillow to Python v3.13.  We are working on migrating to v3.14, but need to mitigate vulnerabilities with 3.13 until then.